### PR TITLE
Fix setup.py and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.pyc
 *.pyo
 cscope.out
+MANIFEST

--- a/README
+++ b/README
@@ -1,0 +1,4 @@
+Custodia
+========
+
+A service to manage, retrieve and store secrets for other processes.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,1 @@
-Custodia
-========
-
-A service to manage, retrieve and store secrets for other processes.
+README

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 jwcrypto
+six

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     url='https://github.com/simo5/custodia',
     packages = ['custodia', 'custodia.httpd', 'custodia.store'],
     data_files = [('share/man/man7', ["man/custodia.7"]),
-                  ('share/doc/custodia', ['COPYING', 'README']),
+                  ('share/doc/custodia', ['LICENSE', 'README']),
                   ('share/doc/custodia/examples', ['custodia.conf']),
                  ],
     scripts = ['custodia/custodia']


### PR DESCRIPTION
setup.py now correctly references LICENSE instead of COPYING. README.md
has been renamed to README and a symbolic link README -> README.md has
been added. distutils is unable to handle a symbolic link as README.

The six package is listed in requirements.txt, too.