### PR TITLE
Fix typos in tests and add cleanup

### DIFF
--- a/custodia/message/kem.py
+++ b/custodia/message/kem.py
@@ -340,7 +340,7 @@ class KEMTests(unittest.TestCase):
         _store_keys(cls.kk.store, KEY_USAGE_ENC, cls.client_keys)
 
     @classmethod
-    def AtearDownClass(self):
+    def tearDownClass(self):
         try:
             os.unlink('kemtests.db')
         except OSError:

--- a/tests/custodia.py
+++ b/tests/custodia.py
@@ -26,8 +26,16 @@ class CustodiaTests(unittest.TestCase):
                            'Content-Type': 'application/json'}
 
     @classmethod
-    def AtearDownClass(self):
-        os.killpg(self.custodia_process.pid, signal.SIGTERM)
+    def tearDownClass(self):
+        try:
+            os.killpg(self.custodia_process.pid, signal.SIGTERM)
+        except OSError:
+            pass
+        for fname in ['server_socket', 'secrets.db']:
+            try:
+                os.unlink(fname)
+            except OSError:
+                pass
 
     def _make_request(self, cmd, path, headers=None, body=None):
         conn = LocalConnection('./server_socket')


### PR DESCRIPTION
The patch fixes to typos in the tear down function of two test suites.
The tests now cleanup and remove temporary files like Unix socket and
test databases.