### PR TITLE
Automatic testing with py.test, coverage and tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,23 @@
+[run]
+branch = True
+source =
+    custodia
+    tests
+
+[paths]
+source =
+   custodia
+   .tox/*/lib/python*/site-packages/custodia
+
+[report]
+ignore_errors = False
+precision = 1
+exclude_lines =
+    pragma: no cover
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if False:
+    if __name__ == .__main__.:
+    if PY3
+    if not PY3

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist/
 *.pyc
 *.pyo
 cscope.out
+.tox
+.coverage
 MANIFEST

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+collect_ignore = ["setup.py", "custodia/custodia"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,60 @@
+[tox]
+envlist = py27,py34,doc,sphinx
+
+[testenv]
+deps =
+    pytest
+    coverage
+    -r{toxinidir}/requirements.txt
+    cryptography
+commands =
+    coverage run -m pytest --capture=no --strict {posargs}
+    coverage report -m
+
+[testenv:pep8]
+basepython = python2.7
+deps =
+    flake8
+    flake8-import-order
+    pep8-naming
+commands =
+    flake8 {posargs}
+
+[testenv:py3pep8]
+basepython = python3.4
+deps =
+    flake8
+    flake8-import-order
+    pep8-naming
+commands =
+    flake8 {posargs}
+
+[testenv:doc]
+deps =
+    doc8
+    docutils
+    markdown
+basepython = python2.7
+commands =
+    doc8 --allow-long-titles README
+    python setup.py check --restructuredtext --metadata --strict
+    markdown_py README.md -f {toxworkdir}/README.md.html
+    markdown_py API.md -f {toxworkdir}/API.md.html
+
+[testenv:sphinx]
+basepython = python2.7
+changedir = docs/source
+deps =
+    sphinx < 1.3.0
+commands =
+    sphinx-build -v -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+[pytest]
+python_files = tests/*.py custodia/*.py
+
+[flake8]
+exclude = .tox,*.egg,dist,build,docs/source
+show-source = true
+max-line-length = 79
+ignore = N802
+application-import-names = custodia


### PR DESCRIPTION
The patch provides test automation with tox. Just run 'tox' in the
source root to create virtual envs, install custodia from the sources
 and run the tests on Python 2.7 and 3.4.

Signed-off-by: Christian Heimes <cheimes@redhat.com>