### PR TITLE
kill() and waitpid() custodia process

### DIFF
--- a/tests/custodia.py
+++ b/tests/custodia.py
@@ -27,10 +27,8 @@ class CustodiaTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(self):
-        try:
-            os.killpg(self.custodia_process.pid, signal.SIGTERM)
-        except OSError:
-            pass
+        self.custodia_process.kill()
+        self.custodia_process.wait()
         for fname in ['server_socket', 'secrets.db']:
             try:
                 os.unlink(fname)


### PR DESCRIPTION
The test suite leaves child processes behind. The teardown class method
now call Popen.kill() and Popen.wait() to kill and wait for its child
process.